### PR TITLE
RFC: Create new 'grubby' grub_class

### DIFF
--- a/manifests/grubby.pp
+++ b/manifests/grubby.pp
@@ -1,0 +1,23 @@
+# Private class.
+class kernel::grubby{
+  if $caller_module_name != $module_name {
+    fail("Use of private class ${name} by ${caller_module_name}")
+  }
+
+  $grub_default_kernel = $kernel::grub_default_kernel ? {
+    'UNSET' => $kernel::kernel_version,
+    default => $kernel::grub_default_kernel,
+  }
+
+  if $kernel::set_default_kernel and $grub_default_kernel != 'UNSET' {
+
+    $_default_kernel = "/boot/vmlinuz-${grub_default_kernel}"
+
+    exec { 'set default kernel':
+      command => "/sbin/grubby --set-default=${_default_kernel}",
+      path    => ['/bin','/usr/bin'],
+      unless  => "/sbin/grubby --default-kernel | grep -q ${_default_kernel}",
+    }
+  }
+
+}


### PR DESCRIPTION
This can be used on both RHEL6 _and_ RHEL7.
/sbin/grubby seems to do the right thing for both :)

So far, manually tested on OEL6 and OEL7.
